### PR TITLE
Add location and media element mocks

### DIFF
--- a/lib/MockBrowser.js
+++ b/lib/MockBrowser.js
@@ -8,6 +8,8 @@ var dash = require('lodash' ),
     JSDOM = require('jsdom').JSDOM,
     AbstractBrowser = require('../lib/AbstractBrowser' ),
     MockStorage = require('../lib/MockStorage');
+const MockHTMLMediaElement = require('./MockHTMLMediaElement');
+const MockLocation = require('./MockLocation');
 
 var MockBrowser = function(options) {
     'use strict';
@@ -25,6 +27,13 @@ var MockBrowser = function(options) {
     else
     {
         var doc = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: "http://localhost" } );
+
+        delete doc.window.location;
+        doc.window.location = new MockLocation();
+        doc.window.HTMLMediaElement = new MockHTMLMediaElement();
+
+        doc.window.scrollTo = () => {};
+
         win = doc.window;
     }
 

--- a/lib/MockHTMLMediaElement.js
+++ b/lib/MockHTMLMediaElement.js
@@ -1,0 +1,16 @@
+var MockHTMLMediaElement = function() {
+    'use strict';
+
+    this.addTextTrack = () => {};
+    this.captureStream = () => {};
+    this.canPlayType = () => {};
+    this.fastSeek = () => {};
+    this.load = () => {};
+    this.pause = () => {};
+    this.play = () => {};
+    this.seekToNextFrame = () => {};
+    this.setMediaKeys = () => {};
+    this.setSinkId = () => {};
+};
+
+module.exports = MockHTMLMediaElement;

--- a/lib/MockLocation.js
+++ b/lib/MockLocation.js
@@ -1,0 +1,10 @@
+var MockLocation = function() {
+    'use strict';
+
+    this.reload = () => {};
+    this.assign = () => {};
+    this.replace = () => {};
+    this.toString = () => {};
+};
+
+module.exports = MockLocation;

--- a/test/MockBrowserTests.js
+++ b/test/MockBrowserTests.js
@@ -7,7 +7,9 @@
 var should = require('chai').should(),
     dash = require('lodash' ),
     MockLogger = require('simple-node-logger' ).mocks.MockLogger,
-    MockBrowser = require('../lib/MockBrowser');
+    MockBrowser = require('../lib/MockBrowser'),
+    MockLocation = require('../lib/MockLocation'),
+    MockHTMLMediaElement = require("../lib/MockHTMLMediaElement");
 
 describe('MockBrowser', function() {
     'use strict';
@@ -149,6 +151,24 @@ describe('MockBrowser', function() {
             should.exist( win.location );
             should.exist( win.navigator );
 
+        });
+
+        it('should have a MockLocation', function() {
+            var win = MockBrowser.createWindow();
+
+            win.location.should.be.instanceof( MockLocation );
+        });
+
+        it('should have a MockHTMLMediaElement', function() {
+            var win = MockBrowser.createWindow();
+
+            win.HTMLMediaElement.should.be.instanceof( MockHTMLMediaElement );
+        });
+
+        it('should have a scrollTo', function() {
+            var win = MockBrowser.createWindow();
+
+            win.scrollTo.should.be.a( 'function' );
         });
     });
 });

--- a/test/MockHTMLMediaElementTests.js
+++ b/test/MockHTMLMediaElementTests.js
@@ -1,0 +1,29 @@
+var should = require('chai').should(),
+dash = require('lodash' ),
+MockLocation = require('../lib/MockLocation');
+
+describe('MockLocation', function() {
+'use strict';
+
+    describe('#instance', function() {
+        var location = new MockLocation(),
+            methods = [
+                'reload',
+                'assign',
+                'replace',
+                'toString'
+            ];
+
+        it('should create an instance of MockLocation', function() {
+            should.exist( location );
+            location.should.be.instanceof( MockLocation );
+        });
+
+        it('should have all known methods by size and type', function() {
+            dash.functionsIn( location ).length.should.equal( methods.length );
+            methods.forEach(function(method) {
+                location[ method ].should.be.a( 'function' );
+            });
+        });
+    });
+});

--- a/test/MockLocationTest.js
+++ b/test/MockLocationTest.js
@@ -1,0 +1,35 @@
+var should = require('chai').should(),
+dash = require('lodash' ),
+MockHTMLMediaElement = require('../lib/MockHTMLMediaElement');
+
+describe('MockHTMLMediaElement', function() {
+'use strict';
+
+    describe('#instance', function() {
+        var mediaElement = new MockHTMLMediaElement(),
+            methods = [
+                'addTextTrack',
+                'captureStream',
+                'canPlayType',
+                'fastSeek',
+                'load',
+                'pause',
+                'play',
+                'seekToNextFrame',
+                'setMediaKeys',
+                'setSinkId'
+            ];
+
+        it('should create an instance of MockHTMLMediaElement', function() {
+            should.exist( mediaElement );
+            mediaElement.should.be.instanceof( MockHTMLMediaElement );
+        });
+
+        it('should have all known methods by size and type', function() {
+            dash.functionsIn( mediaElement ).length.should.equal( methods.length );
+            methods.forEach(function(method) {
+                mediaElement[ method ].should.be.a( 'function' );
+            });
+        });
+    });
+});


### PR DESCRIPTION
Added window location functions mocks and htmlmediaelement mocks. These were available on version 9 but are long gone... so here they are.

Didn't want to add all the window functions ones since we don't really need them... so I added the scrollTo only
